### PR TITLE
Add "Under construction" notice for new visitors

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,1 +1,3 @@
 # Home
+
+This documentation is a work in progress.  Although currently sparse, there are several useful sections, highlighted with "*" on the table of contents.

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -1,4 +1,4 @@
-# Setup
+# *Setup
 
 Getting the Julia extension for VS Code to work involves two steps:
 1) Install VS Code and then,

--- a/docs/src/userguide/codenavigation.md
+++ b/docs/src/userguide/codenavigation.md
@@ -1,4 +1,4 @@
-# Code Navigation
+# *Code Navigation
 
 ## Quick File Navigation
 

--- a/docs/src/userguide/compilesysimage.md
+++ b/docs/src/userguide/compilesysimage.md
@@ -1,4 +1,4 @@
-# Compiling Sysimages
+# *Compiling Sysimages
 
 The Julia VS Code extension makes it easy to compile a custom sysimage for your Julia environments. The extension will also automatically use sysimages for the current environment when it starts a new Julia REPL in VS Code.
 

--- a/docs/src/userguide/runningcode.md
+++ b/docs/src/userguide/runningcode.md
@@ -1,4 +1,4 @@
-# Running Code
+# *Running Code
 
 The Julia extension provides a number of different ways to run your Julia code. This section describes all these options, except how to run code in the debugger, which is covered in a separate part of the documentation.
 


### PR DESCRIPTION
The docs are currently useful,  but some users will not discover that while most pages are empty.
This is a quick fix to draw the eye to the goodness. 
Particularly as there is going to be a lot of traffic from the julia-vscode homepage, landing on the empty index.md is not a great experience.