### PR TITLE
Running code is no longer next section - updated to reflect this

### DIFF
--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -75,4 +75,4 @@ Congratulations! You have just completed your first Julia program.
 ## Learn More
 
 To learn more about the Julia language, see [julialang.org](https://julialang.org).
-To learn more about Julia in Visual Studio Code, countinue browsing around the docs by clicking the ["Running Code"](userguide/runningcode/) button below or using the navigation section on the left.
+To learn more about Julia in Visual Studio Code, countinue browsing around the docs by clicking the ["Running Code"](userguide/runningcode/) in the navigation section on the left.


### PR DESCRIPTION
The text refers to "Running Code" below, but the FAQ section is now the next section and is what is below on the page, hence I pointed merely to the navigation section on the left.