### PR TITLE
Fix instructions for sysimage

### DIFF
--- a/docs/src/userguide/compilesysimage.md
+++ b/docs/src/userguide/compilesysimage.md
@@ -17,11 +17,11 @@ This file should be named `./.vscode/JuliaSysimage.toml` and be placed under the
 ```
 [sysimage]
 exclude=["Pkg1", "Pkg2"]   # Additional packages to be excluded in the system image
-statements_files=["relative/path/to/precompile_statements_file.jl", ]
-execution_files=["relative/path/to/precompile_execution_file.jl", ]
+statements_files=["precompile_statements_file.jl", ]   # relative to Julia project folder
+execution_files=["precompile_execution_file.jl", ]     # relative to Julia project folder
 ```
 The packages to be excluded have to be separated by commas, each with quotation marks and all inside square brackets.
-All path should be relative to the project root folder. The statement or execution files can be given as a single relative path, or as a list of relative paths.
+All path should be relative to the project root folder. This means that the filename is sufficient if the file is located in the project root folder. The statement or execution files can be given as a single relative path, or as a list of relative paths.
 
 The statement files should contain precompile statements of the form `precompile(Tuple{typeof(Base.sin), Float64})`, and the execution files should contain function calls (an example workflow, e.g. making a plot) for which the methods should be compiled. 
 

--- a/docs/src/userguide/compilesysimage.md
+++ b/docs/src/userguide/compilesysimage.md
@@ -12,7 +12,7 @@ By default, all of the packages defined in the `Project.toml` file are included 
 
 Additional options can be passed to further tweak the compilation. In particular, one may want to include script containing the precompile statements or a file to execute certain julia function, which can further reduce the first-call latency. Please read the documentation of [PackageCompiler.jl](https://julialang.github.io/PackageCompiler.jl/stable/) for more details.
 
-This file should be named `./.vscode/JuliaSysimage.toml` and be placed under the project root file. Its content should look like:
+This file should be named `./.vscode/JuliaSysimage.toml` and be placed under the project root folder. For example, the global project root folder for julia 1.6 are found at `~/.julia/environments/v1.6`, so that the `.toml` file could be placed like this: `~/.julia/environments/v1.6/.vscode/JuliaSysimage.toml`. The contents of this file should look like the following:
 
 ```
 [sysimage]
@@ -21,9 +21,9 @@ statements_files=["relative/path/to/precompile_statements_file.jl", ]
 execution_files=["relative/path/to/precompile_execution_file.jl", ]
 ```
 The packages to be excluded have to be separated by commas, each with quotation marks and all inside square brackets.
-The path should be relative to the currently active folder, which can be selected by the command `File: Open Folder...`. The statement or execution files can be given as a single relative path, or as a list of relative paths.
+All path should be relative to the project root folder. The statement or execution files can be given as a single relative path, or as a list of relative paths.
 
-The statement files should contain precompile statements of the form `precompile(Tuple{typeof(Base.sin), Float64})`, and the execution files should contain function calls for which the methods should be compiled. 
+The statement files should contain precompile statements of the form `precompile(Tuple{typeof(Base.sin), Float64})`, and the execution files should contain function calls (an example workflow, e.g. making a plot) for which the methods should be compiled. 
 
 The build task creates a sysimage that includes all packages in the current Julia environment. This sysimage is saved in the same folder where the `Project.toml` and `Manifest.toml` of the current Julia environment are stored. The name of the sysimage file will be `JuliaSysimage.dll` (Windows) or `JuliaSysimage.so`. 
 


### PR DESCRIPTION
I am pretty sure that this is correct now, and it was very wrong before. I am still unable to generate a sysimage, but at least the file is not correctly located and run.

I am getting the following error
```
Activating project at `~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/environments/sysimagecompile/v1.8`
[ Info: Now building a custom sysimage for the environment '/home/dennishb/.julia/environments/v1.8', excluding dev packages 'Symbol[]'.
┌ Info: Included packages: 
│       - Term
│       - Revise
│       - Integrals
│       - Measurements
│       - LinearSolve
│       - Symbolics
│       - DSP
│       - SymbolicNumericIntegration
│       - PyCall
│       - AbbreviatedStackTraces
│       - StatsBase
│       - OhMyREPL
│       - PkgTemplates
│       - Tau
│       - WGLMakie
│       - Latexify
│       - Pluto
│       - IntervalRootFinding
│       - PythonCall
│       - FileIO
│       - MATLAB
│       - TaylorSeries
│       - Tools
│       - PackageCompiler
│       - Unitful
│       - TiffImages
│       - GLMakie
│       - UnicodePlots
│       - EasyFFTs
│       - AutoSysimages
└       - FFTW
[ Info: Precompile statement files: String[]
[ Info: Precompile execution files: ["/home/dennishb/.julia/environments/v1.8/sysimage_excecution_file.jl"]
[ Info: PackageCompiler: Executing /home/dennishb/.julia/environments/v1.8/sysimage_excecution_file.jl => /tmp/jl_packagecompiler_UHllQH/jl_io4aQS
[ Info: Running "sysimage_excecution_file.jl"!   # this info is part of my script, confirming that it is running.
[ Info: PackageCompiler: Done
⢰ [00m:35s] PackageCompiler: compiling incremental system imageER
⠙ [00m:36s] PackageCompiler: compiling incremental system imageDeclaring __precompile__(false) is not allowed in files that are being precompiled.
Stacktrace:
⣄ [00m:37s] PackageCompiler: compiling incremental system imageBool)
   @ Base ./loading.jl:1114
 [2] top-level scope
   @ ~/.julia/packages/AbbreviatedStackTraces/bVmSM/src/AbbreviatedStackTraces.jl:2
 [3] include
   @ ./Base.jl:419 [inlined]
 [4] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1367
 [5] _require_prelocked(uuidkey::Base.PkgId)
   @ Base ./loading.jl:1200
 [6] macro expansion
   @ ./lock.jl:223 [inlined]
 [7] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:1195
 [8] top-level scope
   @ /tmp/jl_OzmdgNq9yn:40
in expression starting at /home/dennishb/.julia/packages/AbbreviatedStackTraces/bVmSM/src/AbbreviatedStackTraces.jl:1
in expression starting at /tmp/jl_OzmdgNq9yn:40
✖ [00m:37s] PackageCompiler: compiling incremental system image
ERROR: LoadError: failed process: Process(`/home/dennishb/.julia/juliaup/julia-1.8.2+0.x64/bin/julia --color=yes --startup-file=no --cpu-target=native -O3 --sysimage=/home/dennishb/.julia/juliaup/julia-1.8.2+0.x64/lib/julia/sys.so --project=/home/dennishb/.julia/environments/v1.8 --output-o=/tmp/jl_0nwD0fSXyd.o /tmp/jl_OzmdgNq9yn`, ProcessExited(1)) [1]

Stacktrace:
 [1] pipeline_error
   @ ./process.jl:565 [inlined]
 [2] run(::Cmd; wait::Bool)
   @ Base ./process.jl:480
 [3] run
   @ ./process.jl:477 [inlined]
 [4] #14
   @ ~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/packages/PackageCompiler/ext/TerminalSpinners.jl:157 [inlined]
 [5] spin(f::PackageCompiler.var"#14#15"{Cmd}, s::PackageCompiler.TerminalSpinners.Spinner{Base.TTY})
   @ PackageCompiler.TerminalSpinners ~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/packages/PackageCompiler/ext/TerminalSpinners.jl:164
 [6] macro expansion
   @ ~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/packages/PackageCompiler/ext/TerminalSpinners.jl:157 [inlined]
 [7] create_sysimg_object_file(object_file::String, packages::Vector{String}, packages_sysimg::Set{Base.PkgId}; project::String, base_sysimage::String, precompile_execution_file::Vector{String}, precompile_statements_file::Vector{String}, cpu_target::String, script::Nothing, sysimage_build_args::Cmd, extra_precompiles::String, incremental::Bool)
   @ PackageCompiler ~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/packages/PackageCompiler/src/PackageCompiler.jl:359
 [8] create_sysimage(packages::Vector{Symbol}; sysimage_path::String, project::String, precompile_execution_file::Vector{String}, precompile_statements_file::Vector{String}, incremental::Bool, filter_stdlibs::Bool, cpu_target::String, script::Nothing, sysimage_build_args::Cmd, include_transitive_dependencies::Bool, base_sysimage::Nothing, julia_init_c_file::Nothing, version::Nothing, soname::Nothing, compat_level::String, extra_precompiles::String)
   @ PackageCompiler ~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/packages/PackageCompiler/src/PackageCompiler.jl:510
 [9] top-level scope
   @ ~/.vscode/extensions/julialang.language-julia-1.38.2/scripts/tasks/task_compileenv.jl:94
in expression starting at /home/dennishb/.vscode/extensions/julialang.language-julia-1.38.2/scripts/tasks/task_compileenv.jl:94

 *  The terminal process "/home/dennishb/.julia/juliaup/julia-1.8.2+0.x64/bin/julia '--color=yes', '--startup-file=no', '--history-file=no', '/home/dennishb/.vscode/extensions/julialang.language-julia-1.38.2/scripts/tasks/task_compileenv.jl', '/home/dennishb/.julia/environments/v1.8'" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. 
```