### PR TITLE
Update docs to include `# %%` code cell markers

### DIFF
--- a/docs/src/userguide/runningcode.md
+++ b/docs/src/userguide/runningcode.md
@@ -32,7 +32,7 @@ The REPL that is started with the `Julia: Start REPL` command will have the root
 There are four commands that you can use to run code from your editor in the Julia REPL:
 
 - `Julia: Execute Code in REPL`
-- `Julia: Execute Code Cell in REPL`
+- `Julia: Execute Code Cell in REPL` / `Julia: Execute Code Cell in REPL and Move`
 - `Julia: Execute File in REPL`
 - `Julia: Run File in New Process`
 
@@ -46,7 +46,7 @@ For most users, this should be their default command to run Julia code in the RE
 
 ### Julia: Execute Code Cell in REPL
 
-The extension provides support for demarking code cells in standard Julia files with a specially formatted comment: `##`. This command will identify in which code cell the cursor in the active editor currently is and then execute the code in that cell. If there are no code cells used in the current file, it will execute the entire file.
+The extension provides support for demarking code cells in standard Julia files with a specially formatted comment: `##` or `# %%`. Either symbol must occur the start of a line and can be followed by text. This command will identify in which code cell the cursor in the active editor currently is and then execute the code in that cell. If there are no code cells used in the current file, it will execute the entire file.
 
 This command uses the same code execution techniques as the `Julia: Execute Code Block` command. Include statements, location information etc. all work as expected, that is run with this command.
 

--- a/docs/src/userguide/weave.md
+++ b/docs/src/userguide/weave.md
@@ -1,5 +1,5 @@
 # Julia Markdown Documents
 
-The extension supports Weave markdown documents with the `.jmd` extension. All Julia code evaluation keybindings and commands should work normally, but cells are defined as fenced Julia code blocks instead (the usual `##` delimiter has no meaning here).
+The extension supports Weave markdown documents with the `.jmd` extension. All Julia code evaluation keybindings and commands should work normally, but cells are defined as fenced Julia code blocks instead (the usual `##`/`# %%` delimiters have no meaning here).
 
 The `Julia Weave: Open Preview` command to weave the current file to a temporary HTML document, which will then be displayed in the editor. `Julia Weave: Save to File...` allows you to select the output format and will save the weaved document next to the source file.


### PR DESCRIPTION
Updating documentation on cell delimiters. The [Jupytext](https://jupytext.readthedocs.io/en/latest/formats-scripts.html) version of cell blocks, `# %%` , is not also an option:
https://github.com/julia-vscode/julia-vscode/blob/6710d6c9b678a601aaa7ce8f2752ca4f72220701/src/interactive/repl.ts#L705C1-L708C2