### PR TITLE
Add @profview_allocs to docs

### DIFF
--- a/docs/src/userguide/profiler.md
+++ b/docs/src/userguide/profiler.md
@@ -20,6 +20,8 @@ end
 @profview profile_test(1)
 # pure runtime
 @profview profile_test(10)
+# viewing allocations
+@profview_allocs profile_test(100)
 ```
 shows a flame graph and inline annotations:
 ![profiler 1](../images/profiler1.png)


### PR DESCRIPTION
add mention of `@profview_allocs` to profiling documentation

Currently, the only way to see mention of this macro is to go to the changelogs and click on the link to the relevant PR. 