### PR TITLE
Add `inventory_version` argument to `Documenter.HTML()`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,6 +41,7 @@ makedocs(
         ]
     ],
     format = Documenter.HTML(
+        inventory_version = "",
         prettyurls = ("CI" in keys(ENV))
     )
 )


### PR DESCRIPTION
Gets rid of the warning when running `makedocs()`